### PR TITLE
Fix ReportTypes comparison in *Action resources - Fixes #8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,17 @@
 - Clean up unit tests and ensure Verbose is enabled on all.
 - Convert AppVeyor build image to Windows Server 2016.
 - FSRMFileScreenAction:
-  - Fix bug comparing ReportTypes array.
+  - Fix bug comparing ReportTypes array in Test-TargetResource.
+  - Fix blank verbose message in Get-TargetResource.
 - FSRMFileScreenTemplateAction:
-  - Fix bug comparing ReportTypes array.
+  - Fix bug comparing ReportTypes array in Test-TargetResource.
+  - Fix blank verbose message in Get-TargetResource.
 - FSRMQuotaAction:
-  - Fix bug comparing ReportTypes array.
+  - Fix bug comparing ReportTypes array in Test-TargetResource.
+  - Fix blank verbose message in Get-TargetResource.
 - FSRMQuotaTemplateAction:
-  - Fix bug comparing ReportTypes array.
-
+  - Fix bug comparing ReportTypes array in Test-TargetResource.
+  - Fix blank verbose message in Get-TargetResource.
 
 ## 2.3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@
   are available for testing.
 - Clean up unit tests and ensure Verbose is enabled on all.
 - Convert AppVeyor build image to Windows Server 2016.
+- FSRMFileScreenAction:
+  - Fix bug comparing ReportTypes array.
+- FSRMFileScreenTemplateAction:
+  - Fix bug comparing ReportTypes array.
+- FSRMQuotaAction:
+  - Fix bug comparing ReportTypes array.
+- FSRMQuotaTemplateAction:
+  - Fix bug comparing ReportTypes array.
+
 
 ## 2.3.0.0
 

--- a/Modules/FSRMDsc/DSCResources/DSR_FSRMFileScreenAction/DSR_FSRMFileScreenAction.psm1
+++ b/Modules/FSRMDsc/DSCResources/DSR_FSRMFileScreenAction/DSR_FSRMFileScreenAction.psm1
@@ -678,7 +678,7 @@ function Test-TargetResource
             }
 
             # Get the existing report types into an array
-            if ($action.ReportTypes -eq $null)
+            if ($null -eq $action.ReportTypes)
             {
                 [System.String[]] $existingReportTypes = @()
             }

--- a/Modules/FSRMDsc/DSCResources/DSR_FSRMFileScreenAction/DSR_FSRMFileScreenAction.psm1
+++ b/Modules/FSRMDsc/DSCResources/DSR_FSRMFileScreenAction/DSR_FSRMFileScreenAction.psm1
@@ -90,7 +90,7 @@ function Get-TargetResource
     {
         Write-Verbose -Message ( @(
                 "$($MyInvocation.MyCommand): "
-                $($LocalizedData.ActionDoesNotExistMessage) `
+                $($LocalizedData.ActionNotExistMessage) `
                     -f $Path, $Type
             ) -join '' )
 

--- a/Modules/FSRMDsc/DSCResources/DSR_FSRMFileScreenAction/DSR_FSRMFileScreenAction.psm1
+++ b/Modules/FSRMDsc/DSCResources/DSR_FSRMFileScreenAction/DSR_FSRMFileScreenAction.psm1
@@ -678,7 +678,7 @@ function Test-TargetResource
             }
 
             if (($PSBoundParameters.ContainsKey('ReportTypes')) `
-                    -and ($action.ReportTypes -ne $ReportTypes))
+                    -and (-not (Compare-Object -ReferenceObject $action.ReportTypes -DifferenceObject $ReportTypes)))
             {
                 Write-Verbose -Message ( @(
                         "$($MyInvocation.MyCommand): "

--- a/Modules/FSRMDsc/DSCResources/DSR_FSRMFileScreenAction/DSR_FSRMFileScreenAction.psm1
+++ b/Modules/FSRMDsc/DSCResources/DSR_FSRMFileScreenAction/DSR_FSRMFileScreenAction.psm1
@@ -677,8 +677,9 @@ function Test-TargetResource
                 $desiredConfigurationMatch = $false
             }
 
-            if (($PSBoundParameters.ContainsKey('ReportTypes')) `
-                    -and (-not (Compare-Object -ReferenceObject $action.ReportTypes -DifferenceObject $ReportTypes)))
+            [System.String[]] $existingReportTypes = $action.ReportTypes
+            if ($PSBoundParameters.ContainsKey('ReportTypes') -and `
+                (Compare-Object -ReferenceObject $existingReportTypes -DifferenceObject $ReportTypes).Count -ne 0)
             {
                 Write-Verbose -Message ( @(
                         "$($MyInvocation.MyCommand): "

--- a/Modules/FSRMDsc/DSCResources/DSR_FSRMFileScreenAction/DSR_FSRMFileScreenAction.psm1
+++ b/Modules/FSRMDsc/DSCResources/DSR_FSRMFileScreenAction/DSR_FSRMFileScreenAction.psm1
@@ -677,7 +677,16 @@ function Test-TargetResource
                 $desiredConfigurationMatch = $false
             }
 
-            [System.String[]] $existingReportTypes = $action.ReportTypes
+            # Get the existing report types into an array
+            if ($action.ReportTypes -eq $null)
+            {
+                [System.String[]] $existingReportTypes = @()
+            }
+            else
+            {
+                [System.String[]] $existingReportTypes = $action.ReportTypes
+            }
+
             if ($PSBoundParameters.ContainsKey('ReportTypes') -and `
                 (Compare-Object -ReferenceObject $existingReportTypes -DifferenceObject $ReportTypes).Count -ne 0)
             {

--- a/Modules/FSRMDsc/DSCResources/DSR_FSRMFileScreenTemplateAction/DSR_FSRMFileScreenTemplateAction.psm1
+++ b/Modules/FSRMDsc/DSCResources/DSR_FSRMFileScreenTemplateAction/DSR_FSRMFileScreenTemplateAction.psm1
@@ -90,7 +90,7 @@ function Get-TargetResource
     {
         Write-Verbose -Message ( @(
                 "$($MyInvocation.MyCommand): "
-                $($LocalizedData.ActionDoesNotExistMessage) `
+                $($LocalizedData.ActionNotExistMessage) `
                     -f $Name, $Type
             ) -join '' )
 

--- a/Modules/FSRMDsc/DSCResources/DSR_FSRMFileScreenTemplateAction/DSR_FSRMFileScreenTemplateAction.psm1
+++ b/Modules/FSRMDsc/DSCResources/DSR_FSRMFileScreenTemplateAction/DSR_FSRMFileScreenTemplateAction.psm1
@@ -676,8 +676,9 @@ function Test-TargetResource
                 $desiredConfigurationMatch = $false
             } # if
 
-            if (($PSBoundParameters.ContainsKey('ReportTypes')) `
-                    -and (-not (Compare-Object -ReferenceObject $action.ReportTypes -DifferenceObject $ReportTypes)))
+            [System.String[]] $existingReportTypes = $action.ReportTypes
+            if ($PSBoundParameters.ContainsKey('ReportTypes') -and `
+                (Compare-Object -ReferenceObject $existingReportTypes -DifferenceObject $ReportTypes).Count -ne 0)
             {
                 Write-Verbose -Message ( @(
                         "$($MyInvocation.MyCommand): "

--- a/Modules/FSRMDsc/DSCResources/DSR_FSRMFileScreenTemplateAction/DSR_FSRMFileScreenTemplateAction.psm1
+++ b/Modules/FSRMDsc/DSCResources/DSR_FSRMFileScreenTemplateAction/DSR_FSRMFileScreenTemplateAction.psm1
@@ -677,7 +677,7 @@ function Test-TargetResource
             } # if
 
             # Get the existing report types into an array
-            if ($action.ReportTypes -eq $null)
+            if ($null -eq $action.ReportTypes)
             {
                 [System.String[]] $existingReportTypes = @()
             }

--- a/Modules/FSRMDsc/DSCResources/DSR_FSRMFileScreenTemplateAction/DSR_FSRMFileScreenTemplateAction.psm1
+++ b/Modules/FSRMDsc/DSCResources/DSR_FSRMFileScreenTemplateAction/DSR_FSRMFileScreenTemplateAction.psm1
@@ -677,7 +677,7 @@ function Test-TargetResource
             } # if
 
             if (($PSBoundParameters.ContainsKey('ReportTypes')) `
-                    -and ($action.ReportTypes -ne $ReportTypes))
+                    -and (-not (Compare-Object -ReferenceObject $action.ReportTypes -DifferenceObject $ReportTypes)))
             {
                 Write-Verbose -Message ( @(
                         "$($MyInvocation.MyCommand): "

--- a/Modules/FSRMDsc/DSCResources/DSR_FSRMFileScreenTemplateAction/DSR_FSRMFileScreenTemplateAction.psm1
+++ b/Modules/FSRMDsc/DSCResources/DSR_FSRMFileScreenTemplateAction/DSR_FSRMFileScreenTemplateAction.psm1
@@ -676,7 +676,16 @@ function Test-TargetResource
                 $desiredConfigurationMatch = $false
             } # if
 
-            [System.String[]] $existingReportTypes = $action.ReportTypes
+            # Get the existing report types into an array
+            if ($action.ReportTypes -eq $null)
+            {
+                [System.String[]] $existingReportTypes = @()
+            }
+            else
+            {
+                [System.String[]] $existingReportTypes = $action.ReportTypes
+            }
+
             if ($PSBoundParameters.ContainsKey('ReportTypes') -and `
                 (Compare-Object -ReferenceObject $existingReportTypes -DifferenceObject $ReportTypes).Count -ne 0)
             {

--- a/Modules/FSRMDsc/DSCResources/DSR_FSRMQuotaAction/DSR_FSRMQuotaAction.psm1
+++ b/Modules/FSRMDsc/DSCResources/DSR_FSRMQuotaAction/DSR_FSRMQuotaAction.psm1
@@ -682,7 +682,7 @@ function Test-TargetResource
             }
 
             if (($PSBoundParameters.ContainsKey('ReportTypes')) `
-                    -and ($action.ReportTypes -ne $ReportTypes))
+                    -and (-not (Compare-Object -ReferenceObject $action.ReportTypes -DifferenceObject $ReportTypes)))
             {
                 Write-Verbose -Message ( @(
                         "$($MyInvocation.MyCommand): "

--- a/Modules/FSRMDsc/DSCResources/DSR_FSRMQuotaAction/DSR_FSRMQuotaAction.psm1
+++ b/Modules/FSRMDsc/DSCResources/DSR_FSRMQuotaAction/DSR_FSRMQuotaAction.psm1
@@ -67,7 +67,7 @@ function Get-TargetResource
     {
         Write-Verbose -Message ( @(
                 "$($MyInvocation.MyCommand): "
-                $($LocalizedData.ActionDoesNotExistMessage) `
+                $($LocalizedData.ActionNotExistMessage) `
                     -f $Path, $Percentage, $Type
             ) -join '' )
 

--- a/Modules/FSRMDsc/DSCResources/DSR_FSRMQuotaAction/DSR_FSRMQuotaAction.psm1
+++ b/Modules/FSRMDsc/DSCResources/DSR_FSRMQuotaAction/DSR_FSRMQuotaAction.psm1
@@ -681,7 +681,16 @@ function Test-TargetResource
                 $desiredConfigurationMatch = $false
             }
 
-            [System.String[]] $existingReportTypes = $action.ReportTypes
+            # Get the existing report types into an array
+            if ($action.ReportTypes -eq $null)
+            {
+                [System.String[]] $existingReportTypes = @()
+            }
+            else
+            {
+                [System.String[]] $existingReportTypes = $action.ReportTypes
+            }
+
             if ($PSBoundParameters.ContainsKey('ReportTypes') -and `
                 (Compare-Object -ReferenceObject $existingReportTypes -DifferenceObject $ReportTypes).Count -ne 0)
             {

--- a/Modules/FSRMDsc/DSCResources/DSR_FSRMQuotaAction/DSR_FSRMQuotaAction.psm1
+++ b/Modules/FSRMDsc/DSCResources/DSR_FSRMQuotaAction/DSR_FSRMQuotaAction.psm1
@@ -682,7 +682,7 @@ function Test-TargetResource
             }
 
             # Get the existing report types into an array
-            if ($action.ReportTypes -eq $null)
+            if ($null -eq $action.ReportTypes)
             {
                 [System.String[]] $existingReportTypes = @()
             }

--- a/Modules/FSRMDsc/DSCResources/DSR_FSRMQuotaAction/DSR_FSRMQuotaAction.psm1
+++ b/Modules/FSRMDsc/DSCResources/DSR_FSRMQuotaAction/DSR_FSRMQuotaAction.psm1
@@ -681,8 +681,9 @@ function Test-TargetResource
                 $desiredConfigurationMatch = $false
             }
 
-            if (($PSBoundParameters.ContainsKey('ReportTypes')) `
-                    -and (-not (Compare-Object -ReferenceObject $action.ReportTypes -DifferenceObject $ReportTypes)))
+            [System.String[]] $existingReportTypes = $action.ReportTypes
+            if ($PSBoundParameters.ContainsKey('ReportTypes') -and `
+                (Compare-Object -ReferenceObject $existingReportTypes -DifferenceObject $ReportTypes).Count -ne 0)
             {
                 Write-Verbose -Message ( @(
                         "$($MyInvocation.MyCommand): "

--- a/Modules/FSRMDsc/DSCResources/DSR_FSRMQuotaTemplateAction/DSR_FSRMQuotaTemplateAction.psm1
+++ b/Modules/FSRMDsc/DSCResources/DSR_FSRMQuotaTemplateAction/DSR_FSRMQuotaTemplateAction.psm1
@@ -683,7 +683,7 @@ function Test-TargetResource
             }
 
             if (($PSBoundParameters.ContainsKey('ReportTypes')) `
-                    -and ($action.ReportTypes -ne $ReportTypes))
+                    -and (-not (Compare-Object -ReferenceObject $action.ReportTypes -DifferenceObject $ReportTypes)))
             {
                 Write-Verbose -Message ( @(
                         "$($MyInvocation.MyCommand): "
@@ -857,9 +857,9 @@ Function Set-Action
             -Namespace Root/Microsoft/Windows/FSRM `
             -ClientOnly `
             -Property @{
-                Percentage = $object.Percentage
-                Action     = [Microsoft.Management.Infrastructure.CimInstance[]]($object.Action)
-            }
+            Percentage = $object.Percentage
+            Action     = [Microsoft.Management.Infrastructure.CimInstance[]]($object.Action)
+        }
     }
 
     Set-FSRMQuotaTemplate `

--- a/Modules/FSRMDsc/DSCResources/DSR_FSRMQuotaTemplateAction/DSR_FSRMQuotaTemplateAction.psm1
+++ b/Modules/FSRMDsc/DSCResources/DSR_FSRMQuotaTemplateAction/DSR_FSRMQuotaTemplateAction.psm1
@@ -682,8 +682,9 @@ function Test-TargetResource
                 $desiredConfigurationMatch = $false
             }
 
-            if (($PSBoundParameters.ContainsKey('ReportTypes')) `
-                    -and (-not (Compare-Object -ReferenceObject $action.ReportTypes -DifferenceObject $ReportTypes)))
+            [System.String[]] $existingReportTypes = $action.ReportTypes
+            if ($PSBoundParameters.ContainsKey('ReportTypes') -and `
+                (Compare-Object -ReferenceObject $existingReportTypes -DifferenceObject $ReportTypes).Count -ne 0)
             {
                 Write-Verbose -Message ( @(
                         "$($MyInvocation.MyCommand): "

--- a/Modules/FSRMDsc/DSCResources/DSR_FSRMQuotaTemplateAction/DSR_FSRMQuotaTemplateAction.psm1
+++ b/Modules/FSRMDsc/DSCResources/DSR_FSRMQuotaTemplateAction/DSR_FSRMQuotaTemplateAction.psm1
@@ -682,7 +682,16 @@ function Test-TargetResource
                 $desiredConfigurationMatch = $false
             }
 
-            [System.String[]] $existingReportTypes = $action.ReportTypes
+            # Get the existing report types into an array
+            if ($action.ReportTypes -eq $null)
+            {
+                [System.String[]] $existingReportTypes = @()
+            }
+            else
+            {
+                [System.String[]] $existingReportTypes = $action.ReportTypes
+            }
+
             if ($PSBoundParameters.ContainsKey('ReportTypes') -and `
                 (Compare-Object -ReferenceObject $existingReportTypes -DifferenceObject $ReportTypes).Count -ne 0)
             {

--- a/Modules/FSRMDsc/DSCResources/DSR_FSRMQuotaTemplateAction/DSR_FSRMQuotaTemplateAction.psm1
+++ b/Modules/FSRMDsc/DSCResources/DSR_FSRMQuotaTemplateAction/DSR_FSRMQuotaTemplateAction.psm1
@@ -683,7 +683,7 @@ function Test-TargetResource
             }
 
             # Get the existing report types into an array
-            if ($action.ReportTypes -eq $null)
+            if ($null -eq $action.ReportTypes)
             {
                 [System.String[]] $existingReportTypes = @()
             }

--- a/Modules/FSRMDsc/DSCResources/DSR_FSRMQuotaTemplateAction/DSR_FSRMQuotaTemplateAction.psm1
+++ b/Modules/FSRMDsc/DSCResources/DSR_FSRMQuotaTemplateAction/DSR_FSRMQuotaTemplateAction.psm1
@@ -67,7 +67,7 @@ function Get-TargetResource
     {
         Write-Verbose -Message ( @(
                 "$($MyInvocation.MyCommand): "
-                $($LocalizedData.ActionDoesNotExistMessage) `
+                $($LocalizedData.ActionNotExistMessage) `
                     -f $Name, $Percentage, $Type
             ) -join '' )
 

--- a/Tests/Unit/DSR_FSRMFileScreenAction.Tests.ps1
+++ b/Tests/Unit/DSR_FSRMFileScreenAction.Tests.ps1
@@ -87,9 +87,24 @@ try
             Active       = $true
             IncludeGroup = @( 'Audio and Video Files', 'Executable Files', 'Backup Files' )
             Notification = [Microsoft.Management.Infrastructure.CimInstance[]]@(
-                $script:MockEmail, $script:MockCommand, $script:MockEvent, $script:MockReport
+                $script:MockEmail, $script:MockCommand, $script:MockEvent
             )
         }
+
+        $script:MockFileScreenReportOnly = New-CimInstance `
+        -ClassName 'MSFT_FSRMFileScreen' `
+        -Namespace Root/Microsoft/Windows/FSRM `
+        -ClientOnly `
+        -Property @{
+        Path         = $ENV:Temp
+        Description  = 'File Screen Templates for Blocking Some Files'
+        Ensure       = 'Present'
+        Active       = $true
+        IncludeGroup = @( 'Audio and Video Files', 'Executable Files', 'Backup Files' )
+        Notification = [Microsoft.Management.Infrastructure.CimInstance[]]@(
+            $script:MockReport
+        )
+    }
 
         $script:TestFileScreenActionEmail = [PSObject]@{
             Path    = $script:MockFileScreen.Path
@@ -486,7 +501,7 @@ try
             }
 
             Context 'File Screen exists and action with different ReportTypes exists' {
-                Mock -CommandName Get-FsrmFileScreen -MockWith { return @($script:MockFileScreen) }
+                Mock -CommandName Get-FsrmFileScreen -MockWith { return @($script:MockFileScreenReportOnly) }
 
                 It 'Should return false' {
                     $testTargetResourceParameters = $script:TestFileScreenActionSetReport.Clone()

--- a/Tests/Unit/DSR_FSRMFileScreenAction.Tests.ps1
+++ b/Tests/Unit/DSR_FSRMFileScreenAction.Tests.ps1
@@ -87,7 +87,7 @@ try
             Active       = $true
             IncludeGroup = @( 'Audio and Video Files', 'Executable Files', 'Backup Files' )
             Notification = [Microsoft.Management.Infrastructure.CimInstance[]]@(
-                $script:MockEmail, $script:MockCommand, $script:MockEvent
+                $script:MockEmail, $script:MockCommand, $script:MockEvent, $script:MockReport
             )
         }
 

--- a/Tests/Unit/DSR_FSRMFileScreenTemplateAction.Tests.ps1
+++ b/Tests/Unit/DSR_FSRMFileScreenTemplateAction.Tests.ps1
@@ -87,7 +87,7 @@ try
             Active       = $true
             IncludeGroup = @( 'Audio and Video Files', 'Executable Files', 'Backup Files' )
             Notification = [Microsoft.Management.Infrastructure.CimInstance[]]@(
-                $script:MockEmail, $script:MockCommand, $script:MockEvent
+                $script:MockEmail, $script:MockCommand, $script:MockEvent, $script:MockReport
             )
         }
 

--- a/Tests/Unit/DSR_FSRMFileScreenTemplateAction.Tests.ps1
+++ b/Tests/Unit/DSR_FSRMFileScreenTemplateAction.Tests.ps1
@@ -87,9 +87,24 @@ try
             Active       = $true
             IncludeGroup = @( 'Audio and Video Files', 'Executable Files', 'Backup Files' )
             Notification = [Microsoft.Management.Infrastructure.CimInstance[]]@(
-                $script:MockEmail, $script:MockCommand, $script:MockEvent, $script:MockReport
+                $script:MockEmail, $script:MockCommand, $script:MockEvent
             )
         }
+
+        $script:MockFileScreenTemplateReportOnly = New-CimInstance `
+        -ClassName 'MSFT_FSRMFileScreenTemplate' `
+        -Namespace Root/Microsoft/Windows/FSRM `
+        -ClientOnly `
+        -Property @{
+        Name         = 'Block Some Files'
+        Description  = 'File Screen Templates for Blocking Some Files'
+        Ensure       = 'Present'
+        Active       = $true
+        IncludeGroup = @( 'Audio and Video Files', 'Executable Files', 'Backup Files' )
+        Notification = [Microsoft.Management.Infrastructure.CimInstance[]]@(
+            $script:MockReport
+        )
+    }
 
         $script:TestFileScreenTemplateActionEmail = [PSObject]@{
             Name    = $script:MockFileScreenTemplate.Name
@@ -488,7 +503,7 @@ try
 
             Context 'File Screen template exists and action with different ReportTypes exists' {
 
-                Mock -CommandName Get-FsrmFileScreenTemplate -MockWith { return @($script:MockFileScreenTemplate) }
+                Mock -CommandName Get-FsrmFileScreenTemplate -MockWith { return @($script:MockFileScreenTemplateReportOnly) }
 
                 It 'Should return false' {
                     $testTargetResourceParameters = $script:TestFileScreenTemplateActionSetReport.Clone()


### PR DESCRIPTION
**Pull Request (PR) description**
- FSRMFileScreenAction:
  - Fix bug comparing ReportTypes array in Test-TargetResource.
  - Fix blank verbose message in Get-TargetResource.
- FSRMFileScreenTemplateAction:
  - Fix bug comparing ReportTypes array in Test-TargetResource.
  - Fix blank verbose message in Get-TargetResource.
- FSRMQuotaAction:
  - Fix bug comparing ReportTypes array in Test-TargetResource.
  - Fix blank verbose message in Get-TargetResource.
- FSRMQuotaTemplateAction:
  - Fix bug comparing ReportTypes array in Test-TargetResource.
  - Fix blank verbose message in Get-TargetResource.

**This Pull Request (PR) fixes the following issues:**
- Fixes #8

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/fsrmdsc/10)
<!-- Reviewable:end -->
